### PR TITLE
Upd. POM to incl. internal mvn and aws-maven extension.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,32 @@
 		</org.apache.httpcomponents.httpclient.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>aws-release</id>
+			<name>AWS Release Repository</name>
+			<url>s3://mvn.spongecell.com/releases</url>
+		</repository>
+		<repository>
+			<id>aws-snapshot</id>
+			<name>AWS Snapshot Repository</name>
+			<url>s3://mvn.spongecell.com/snapshots</url>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<repository>
+			<id>aws-release</id>
+			<name>AWS Release Repository</name>
+			<url>s3://mvn.spongecell.com/releases</url>
+		</repository>
+		<snapshotRepository>
+			<id>aws-snapshot</id>
+			<name>AWS Snapshot Repository</name>
+			<url>s3://mvn.spongecell.com/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -107,6 +133,13 @@
 	</dependencies>
 
 	<build>
+		<extensions>
+			<extension>
+				<groupId>org.springframework.build</groupId>
+				<artifactId>aws-maven</artifactId>
+				<version>5.0.0.RELEASE</version>
+			</extension>
+		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
As with [Spongecell/webhdfs](https://github.com/Spongecell/webhdfs), this resolves the following maven error, causing jenkins builds to fail.  The `webhdfs-build` job in jenkins is currently building against the `bchroneos001` branch.

```
[ERROR] Failed to execute goal on project webhdfs: Could not resolve dependencies for project spongecell:webhdfs:jar:0.0.1-SNAPSHOT: Failed to collect dependencies at spongecell-spring-libraries.events:event-handler:jar:1.0: Failed to read artifact descriptor for spongecell-spring-libraries.events:event-handler:jar:1.0: Could not find artifact spongecell-spring:spongecell-spring-libraries:pom:0.0.1-SNAPSHOT -> [Help 1]
```